### PR TITLE
fix spacing in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Once there, you can run the next bash script. This sets up the ipykernels that s
 `source init_pykernels.sh`
 
 After that, create a new notebook and connect it to a kernel by clicking on the kernel tab and selecting the kernel that is called "Python (nlp_env)"
+
 <img src="kernel_setup.png" width="250" />
 
 If you cannot run cells right now, you might need to kickstart the notebook by running the "validate" button on top and waiting a minute for the backend/kernel to get setup. 


### PR DESCRIPTION
Having only a single newline before the image made it appear inline and messed with the readability of the text.

Before:
![image](https://user-images.githubusercontent.com/27079662/175184084-e0627c29-071b-4610-9e9b-c4b0fedf0d88.png)

After:
![image](https://user-images.githubusercontent.com/27079662/175184169-9a5b3866-fb10-437d-91ce-0237af381b38.png)